### PR TITLE
fix:修改构建报错，删除importsNotUsedAsValues配置项

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
   },
   "homepage": "https://github.com/a7ul/react-native-exception-handler",
   "dependencies": {
-    "react-native-exception-handler": "2.10.10"
+    "react-native-exception-handler": "2.10.10",
+    "react": "18.2.0",
+    "react-native": "0.72.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.12",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
       "allowUnreachableCode": false,
       "allowUnusedLabels": false,
       "esModuleInterop": true,
-      "importsNotUsedAsValues": "error",
       "forceConsistentCasingInFileNames": true,
       "lib": ["esnext"],
       "module": "esnext",


### PR DESCRIPTION
- Close #16 
# Summary
修改构建报错，删除tsconfig.json中的importsNotUsedAsValues配置项

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)